### PR TITLE
Render curated-agreements in github main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+curated-ageements.md


### PR DESCRIPTION
This commit links curated-ageements.md to README.md so that it is
automatically rendered in Github and other hosting's main repository
page.


See my [fork](https://github.com/omeid/curated-agreements) for this change in action.